### PR TITLE
feat: add MTU threshold and configurable resend packet

### DIFF
--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -166,6 +166,11 @@ namespace camera_lucid {
          * using PTPSync)
          */
         uint64_t frame_transmission_delay = 0;
+
+        /** Configures the MTU. Lucid Arena SDK negotiates automatically the packet size.
+         * However, we have this param to ensure the minimum acceptable value. If the MTU
+         * value is bellow this threshold an exception is thrown.*/
+        int mtu_threshold = 9000;
     };
 
     struct ImageConfig {

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -150,6 +150,8 @@ namespace camera_lucid {
     };
 
     struct TransmissionConfig {
+        /** Whether the Arena software requires a packet resend*/
+        bool stream_packet_resend = true;
         /** Whether the camera controls data transfer (false), or the component (true) */
         bool explicit_data_transfer = false;
         /** Delay between two packets sent by the camera in nanoseconds
@@ -176,7 +178,7 @@ namespace camera_lucid {
          * the desired mtu is configured or if timeouts.*/
         base::Time mtu_check_sleep = base::Time::fromMilliseconds(500);
         /** Timeout for negotiating mtu.*/
-        base::Time mtu_check_timeout = base::Time::fromSeconds(2);
+        base::Time mtu_check_timeout = base::Time::fromSeconds(10);
     };
 
     struct ImageConfig {

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -170,7 +170,13 @@ namespace camera_lucid {
         /** Configures the MTU. Lucid Arena SDK negotiates automatically the packet size.
          * However, we have this param to ensure the minimum acceptable value. If the MTU
          * value is bellow this threshold an exception is thrown.*/
-        int mtu_threshold = 9000;
+        int mtu_threshold = 1500;
+
+        /** Sleep while checking mtu value. The configurable task will be in a  loop until
+         * the desired mtu is configured or if timeouts.*/
+        base::Time mtu_check_sleep = base::Time::fromMilliseconds(500);
+        /** Timeout for negotiating mtu.*/
+        base::Time mtu_check_timeout = base::Time::fromSeconds(2);
     };
 
     struct ImageConfig {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -296,7 +296,7 @@ void Task::configureCamera(Arena::IDevice& device, System& system)
     LOG_INFO_S << "Setting StreamPacketResendEnable.";
     Arena::SetNodeValue<bool>(device.GetTLStreamNodeMap(),
         "StreamPacketResendEnable",
-        true);
+        _transmission_config.get().stream_packet_resend);
 
     LOG_INFO_S << "Setting PixelFormat.";
     Arena::SetNodeValue<GenICam::gcstring>(device.GetNodeMap(),

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -131,6 +131,7 @@ argument.
         void infoConfiguration(Arena::IDevice& device);
         void analogConfiguration(Arena::IDevice& device);
         void transmissionConfiguration(Arena::IDevice& device);
+        bool checkMtu(Arena::IDevice& device, int64_t mtu);
 
         void collectInfo();
         void acquireFrame();


### PR DESCRIPTION
With this feature we can ensure that we are transmitting using jumbo packages (MTU 9000 for example).
