### PR TITLE
feat: add possiblility of setting a fixed MTU

### DIFF
--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -170,9 +170,15 @@ namespace camera_lucid {
         uint64_t frame_transmission_delay = 0;
 
         /** Configures the MTU. Lucid Arena SDK negotiates automatically the packet size.
-         * However, we have this param to ensure the minimum acceptable value. If the MTU
-         * value is bellow this threshold an exception is thrown.*/
-        int mtu_threshold = 1500;
+         * If true, the mtu negotiation will be done automatically and it will be checked
+         * if the negotiated mtu is greater or equal than the desired mtu.
+         * If false, the mtu will be set as desired mtu.*/
+        bool auto_negotiate_mtu = false;
+
+        /** Desired mtu
+         * If the camera's mtu value is bellow this value, after the timeout an exception
+         * is thrown.*/
+        int mtu = 1500;
 
         /** Sleep while checking mtu value. The configurable task will be in a  loop until
          * the desired mtu is configured or if timeouts.*/


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
Sometimes the MTU negotiation does not get the maximum MTU available. This modification allows the possibility of configuring a fixed mtu instead of using the auto negotiation.
# How I did it
<!-- Explain a little bit of your implementation -->
Added a new parameter for configuration.

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->
Created a small program with this function and tested on Tupan.

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [x] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [x] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
