### PR TITLE
feat: Add Vertical/Horizontal Flip options to lucid

### DIFF
--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -230,6 +230,14 @@ namespace camera_lucid {
         /** Default pixel value the camera will try to reach automatically.
          * For uncontrolled outdoor environments, the recommended value is 70. */
         uint8_t target_brightness = 70;
+        /** Horizontal Flip
+         * The flip action occurs on the camera before transmitting the image to the host.
+         */
+        bool horizontal_flip = false;
+        /** Vertical Flip
+         * The flip action occurs on the camera before transmitting the image to the host.
+         */
+        bool vertical_flip = false;
     };
 
     struct CameraConfig {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -328,7 +328,7 @@ void Task::configureCamera(Arena::IDevice& device, System& system)
     acquisitionConfiguration(device);
     binningConfiguration(device);
     decimationConfiguration(device);
-    dimensionsConfiguration(device);
+    imageFormatConfiguration(device);
     exposureConfiguration(device);
     analogConfiguration(device);
     infoConfiguration(device);
@@ -711,7 +711,7 @@ void Task::decimationConfiguration(Arena::IDevice& device)
     }
 }
 
-void Task::dimensionsConfiguration(Arena::IDevice& device)
+void Task::imageFormatConfiguration(Arena::IDevice& device)
 {
     LOG_INFO_S << "Setting Dimensions.";
     GenApi::CIntegerPtr width = device.GetNodeMap()->GetNode("Width");
@@ -754,6 +754,16 @@ void Task::dimensionsConfiguration(Arena::IDevice& device)
             Arena::GetNodeValue<int64_t>(device.GetNodeMap(), "OffsetY")) {
         throw runtime_error("Width/Heigth/Offset not properly configured.");
     }
+
+    LOG_INFO_S << "Setting Horizontal Flip";
+    Arena::SetNodeValue<bool>(device.GetNodeMap(),
+        "ReverseX",
+        _image_config.get().horizontal_flip);
+
+    LOG_INFO_S << "Setting Horizontal Flip";
+    Arena::SetNodeValue<bool>(device.GetNodeMap(),
+        "ReverseY",
+        _image_config.get().vertical_flip);
 }
 
 void Task::exposureConfiguration(Arena::IDevice& device)

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -126,7 +126,7 @@ argument.
         void acquisitionConfiguration(Arena::IDevice& device);
         void binningConfiguration(Arena::IDevice& device);
         void decimationConfiguration(Arena::IDevice& device);
-        void dimensionsConfiguration(Arena::IDevice& device);
+        void imageFormatConfiguration(Arena::IDevice& device);
         void exposureConfiguration(Arena::IDevice& device);
         void infoConfiguration(Arena::IDevice& device);
         void analogConfiguration(Arena::IDevice& device);


### PR DESCRIPTION
<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
This PR allows the camera to flip the image horizontally and vertically. The flip action occurs on the camera before transmitting the image to the host.
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:

[sc-32799]