### PR TITLE
Revert "feat: Add Vertical/Horizontal Flip options to lucid"

### DIFF
--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -230,14 +230,6 @@ namespace camera_lucid {
         /** Default pixel value the camera will try to reach automatically.
          * For uncontrolled outdoor environments, the recommended value is 70. */
         uint8_t target_brightness = 70;
-        /** Horizontal Flip
-         * The flip action occurs on the camera before transmitting the image to the host.
-         */
-        bool horizontal_flip = false;
-        /** Vertical Flip
-         * The flip action occurs on the camera before transmitting the image to the host.
-         */
-        bool vertical_flip = false;
     };
 
     struct CameraConfig {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -328,7 +328,7 @@ void Task::configureCamera(Arena::IDevice& device, System& system)
     acquisitionConfiguration(device);
     binningConfiguration(device);
     decimationConfiguration(device);
-    imageFormatConfiguration(device);
+    dimensionsConfiguration(device);
     exposureConfiguration(device);
     analogConfiguration(device);
     infoConfiguration(device);
@@ -711,7 +711,7 @@ void Task::decimationConfiguration(Arena::IDevice& device)
     }
 }
 
-void Task::imageFormatConfiguration(Arena::IDevice& device)
+void Task::dimensionsConfiguration(Arena::IDevice& device)
 {
     LOG_INFO_S << "Setting Dimensions.";
     GenApi::CIntegerPtr width = device.GetNodeMap()->GetNode("Width");
@@ -754,16 +754,6 @@ void Task::imageFormatConfiguration(Arena::IDevice& device)
             Arena::GetNodeValue<int64_t>(device.GetNodeMap(), "OffsetY")) {
         throw runtime_error("Width/Heigth/Offset not properly configured.");
     }
-
-    LOG_INFO_S << "Setting Horizontal Flip";
-    Arena::SetNodeValue<bool>(device.GetNodeMap(),
-        "ReverseX",
-        _image_config.get().horizontal_flip);
-
-    LOG_INFO_S << "Setting Horizontal Flip";
-    Arena::SetNodeValue<bool>(device.GetNodeMap(),
-        "ReverseY",
-        _image_config.get().vertical_flip);
 }
 
 void Task::exposureConfiguration(Arena::IDevice& device)

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -126,7 +126,7 @@ argument.
         void acquisitionConfiguration(Arena::IDevice& device);
         void binningConfiguration(Arena::IDevice& device);
         void decimationConfiguration(Arena::IDevice& device);
-        void imageFormatConfiguration(Arena::IDevice& device);
+        void dimensionsConfiguration(Arena::IDevice& device);
         void exposureConfiguration(Arena::IDevice& device);
         void infoConfiguration(Arena::IDevice& device);
         void analogConfiguration(Arena::IDevice& device);


### PR DESCRIPTION
[sc-33054]
This modification triggered an odd behavior. The camera worked at first run but during reconfiguration the camera broke.
After a quick investigation, it was noticed that the field PixelFormat was randomly modified and it wasn't writable anymore 
This needed further investigation, however, due the lack of time, we chose  another approach ..