### PR TITLE
fix: move received timestamp closer to when frame is acquired

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -359,6 +359,7 @@ void Task::configureCamera(Arena::IDevice& device, System& system)
 void Task::acquireFrame()
 {
     RequeueImageFrame frame;
+    base::Time received_time;
     try {
         if (_transmission_config.get().explicit_data_transfer) {
             Arena::ExecuteNode(m_device->GetNodeMap(), "TransferStart");
@@ -366,6 +367,7 @@ void Task::acquireFrame()
         frame.reset(
             m_device->GetImage(_image_config.get().frame_timeout.toMilliseconds()),
             m_device);
+        received_time = base::Time::now();
         if (_transmission_config.get().explicit_data_transfer) {
             Arena::ExecuteNode(m_device->GetNodeMap(), "TransferStop");
         }
@@ -403,9 +405,8 @@ void Task::acquireFrame()
         format != out_frame->getFrameMode()) {
         out_frame->init(width, height, data_depth, format, 0, size);
     }
-    out_frame->time = base::Time::now();
-    out_frame->received_time = out_frame->time;
-
+    out_frame->time = received_time;
+    out_frame->received_time = received_time;
     out_frame->setImage(frame.image->GetData(), size);
     out_frame->setStatus(STATUS_VALID);
     m_frame.reset(out_frame);


### PR DESCRIPTION


<!--
Depends on:
- [ ]

-->
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here
- [ ] [Shortcut](http://) -->
The frame timestamp used is not the timestamp at the moment of the frame capture.This might be an issue when synchronizing with the transforms.
At the moment the frame timestamp is generated on the syskit side, when the base::frame is created. This PR to moves the timestamp acquisition as close as possible to when we receiving the frames.
# How I did it
<!-- Explain a little bit of your implementation -->

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->

# Checklist
- [x] Assign yourself  in the PR
- [ ] Write unit tests (when relevant)
- [ ] Run rubocop and rake tests locally
- [ ] If this PR initialize a CMAKE package please [enable styling and linting](https://github.com/tidewise/wetpaint-buildconf/blob/master/README.md#enabling-styling-and-linting-checks-for-a-cmake-package)
- [ ] Analyse if this PR modifies the UI, if so:
    - [ ] Tested Tupan's simulation (Charts) :world_map:
    - [ ] Tested Tupan's simulation (Hud) :joystick:
    - [ ] Tested ROV's simulation :joystick:
