### PR TITLE
feat: add autoexposure and whitebalance configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,3 +3,17 @@ project(camera_lucid VERSION 0.0)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.orogen/config")
 include(camera_lucidBase)
+
+# How to enable tests:
+# To enable tests, rename "online_test" folder to "test"
+# (without quotes) uncomment the if statement,
+# run "autoproj test enable ." (don't forget the dot) inside
+# the drivers/orogen/camera_lucid folder and then amake --force
+# finally, "run autoproj test . --tool" and remember to alter
+# task_test.rb ip to match the cameras ip.
+
+# if (ROCK_TEST_ENABLED)
+#     enable_testing()
+#     find_package(Syskit REQUIRED)
+#     syskit_orogen_tests(test)
+# endif()

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -317,6 +317,8 @@ namespace camera_lucid {
         uint64_t incomplete_images = 0;
         /** Mean exposure time*/
         uint64_t average_exposure;
+        /* Current balance ratio*/
+        float current_balance_ratio;
     };
 }
 

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -49,7 +49,7 @@ namespace camera_lucid {
         EXPOSURE_AUTO_ALGORITHM_MEDIAN = 0,
         EXPOSURE_AUTO_ALGORITHM_MEAN = 1
     };
-    static std::vector<std::string> exposure_auto_algorithm = {"Median", "Mean"};
+    static std::vector<std::string> exposure_auto_algorithm_name = {"Median", "Mean"};
 
     enum ExposureAutoLimitAuto {
         EXPOSURE_AUTO_LIMIT_AUTO_OFF = 0,

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -77,6 +77,15 @@ namespace camera_lucid {
     };
     static std::vector<std::string> gain_auto_name = {"Off", "Once", "Continuous"};
 
+    enum BalanceRatioSelector {
+        BALANCE_RATIO_SELECTOR_RED = 0,
+        BALANCE_RATIO_SELECTOR_GREEN = 1,
+        BALANCE_RATIO_SELECTOR_BLUE = 2
+    };
+    static std::vector<std::string> balance_ratio_selector_name = {"Red",
+        "Green",
+        "Blue"};
+
     enum BalanceWhiteAuto {
         BALANCE_WHITE_AUTO_OFF = 0,
         BALANCE_WHITE_AUTO_ONCE = 1,
@@ -162,6 +171,10 @@ namespace camera_lucid {
         float gamma = 0.5;
         /** Balance White Enable - Enables the White Balance */
         bool balance_white_enable = true;
+        /** Balance Ratio Selector - Selects which balance ratio is controlled by
+         *  various balance ratio features.*/
+        BalanceRatioSelector balance_ratio_selector =
+            BalanceRatioSelector::BALANCE_RATIO_SELECTOR_RED;
         /** Balance White Auto - Controls the mode for automatic white balancing
          *  between color channels.*/
         BalanceWhiteAuto balance_white_auto =

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -95,8 +95,7 @@ namespace camera_lucid {
         "Once",
         "Continuous"};
 
-    enum BalanceWhiteAutoAnchorSelector { // This RGB seems strange.. idk, need to check
-                                          // it later.
+    enum BalanceWhiteAutoAnchorSelector {
         BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MINRGB = 0,
         BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MAXRGB = 1,
         BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MEANRGB = 2,
@@ -262,6 +261,8 @@ namespace camera_lucid {
             base::samples::frame::frame_mode_t::MODE_BAYER_RGGB;
         /** Depth*/
         uint8_t depth = 8;
+        /** Short Exposure State*/
+        bool short_exposure_enable = false;
         /** Sets the automatic exposure mode.*/
         ExposureAuto exposure_auto = EXPOSURE_AUTO_CONTINUOUS;
         /** Sets the automatic exposure algorithm*/

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -85,7 +85,7 @@ namespace camera_lucid {
     static std::vector<std::string> balance_ratio_selector_name = {"Red",
         "Green",
         "Blue"};
-
+    // Despite the fact we should be able to set it to Once, the driver doesn't accept it.
     enum BalanceWhiteAuto {
         BALANCE_WHITE_AUTO_OFF = 0,
         BALANCE_WHITE_AUTO_ONCE = 1,

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -77,6 +77,27 @@ namespace camera_lucid {
     };
     static std::vector<std::string> gain_auto_name = {"Off", "Once", "Continuous"};
 
+    enum BalanceWhiteAuto {
+        BALANCE_WHITE_AUTO_OFF = 0,
+        BALANCE_WHITE_AUTO_ONCE = 1,
+        BALANCE_WHITE_AUTO_CONTINUOUS = 2
+    };
+    static std::vector<std::string> balance_white_auto_name = {"Off",
+        "Once",
+        "Continuous"};
+
+    enum BalanceWhiteAutoAnchorSelector { // This RGB seems strange.. idk, need to check
+                                          // it later.
+        BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MINRGB = 0,
+        BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MAXRGB = 1,
+        BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MEANRGB = 2,
+        BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_GREEN = 3
+    };
+    static std::vector<std::string> balance_white_auto_anchor_selector_name = {"MinRGB",
+        "MaxRGB",
+        "MeanRGB",
+        "Green"};
+
     enum AcquisitionStartMode {
         ACQUISITION_START_MODE_NORMAL = 0,
         ACQUISITION_START_MODE_LOWLATENCY = 1,
@@ -139,6 +160,16 @@ namespace camera_lucid {
         /** Gamma correction configuration - For uncontrolled outdoor environments,
          * The recommended gamma value is 0.5. */
         float gamma = 0.5;
+        /** Balance White Enable - Enables the White Balance */
+        bool balance_white_enable = true;
+        /** Balance White Auto - Controls the mode for automatic white balancing
+         *  between color channels.*/
+        BalanceWhiteAuto balance_white_auto =
+            BalanceWhiteAuto::BALANCE_WHITE_AUTO_CONTINUOUS;
+        /** Balance White Auto Anchor Selector - Controls which type of statistics
+         *  are used for BalanceWhiteAuto.*/
+        BalanceWhiteAutoAnchorSelector balance_white_auto_anchor_selector =
+            BalanceWhiteAutoAnchorSelector::BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MEANRGB;
     };
 
     struct PTPConfig {

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -261,7 +261,10 @@ namespace camera_lucid {
             base::samples::frame::frame_mode_t::MODE_BAYER_RGGB;
         /** Depth*/
         uint8_t depth = 8;
-        /** Short Exposure State*/
+        /** Short Exposure State
+         *  This state needs a exposure_time between 2.464 and 1 microseconds
+         *  and is not compatible with Exposure_Auto_Limit_Auto_OFF when in
+         *  EXPOSURE_AUTO_CONTINUOUS. */
         bool short_exposure_enable = false;
         /** Sets the automatic exposure mode.*/
         ExposureAuto exposure_auto = EXPOSURE_AUTO_CONTINUOUS;

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -176,7 +176,7 @@ namespace camera_lucid {
         BalanceRatioSelector balance_ratio_selector =
             BalanceRatioSelector::BALANCE_RATIO_SELECTOR_RED;
         /** Balance Ratio - Controls the selected balance ratio as an absolute physical
-         * value */
+         * value. This is an amplification factor applied to the video signal.*/
         float balance_ratio = 1.0684;
         /** Balance White Auto - Controls the mode for automatic white balancing
          *  between color channels.*/
@@ -312,7 +312,7 @@ namespace camera_lucid {
         /** Number of incomplete images since start*/
         uint64_t incomplete_images = 0;
         /** Mean exposure time*/
-        uint16_t mean_exposure; // the pattern may be different (unit64_t)
+        uint64_t average_exposure;
     };
 }
 

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -45,6 +45,12 @@ namespace camera_lucid {
     };
     static std::vector<std::string> exposure_auto_name = {"Off", "Once", "Continuous"};
 
+    enum ExposureAutoAlgorithm {
+        EXPOSURE_AUTO_ALGORITHM_MEDIAN = 0,
+        EXPOSURE_AUTO_ALGORITHM_MEAN = 1
+    };
+    static std::vector<std::string> exposure_auto_algorithm = {"Median", "Mean"};
+
     enum ExposureAutoLimitAuto {
         EXPOSURE_AUTO_LIMIT_AUTO_OFF = 0,
         EXPOSURE_AUTO_LIMIT_AUTO_CONTINUOUS = 1
@@ -211,6 +217,11 @@ namespace camera_lucid {
         uint8_t depth = 8;
         /** Sets the automatic exposure mode.*/
         ExposureAuto exposure_auto = EXPOSURE_AUTO_CONTINUOUS;
+        /** Sets the automatic exposure algorithm*/
+        ExposureAutoAlgorithm exposure_auto_algorithm = EXPOSURE_AUTO_ALGORITHM_MEAN;
+        /** Sets the automatic exposure damping represented as %.
+         * Maximum, Minimum: 99.6094, 0.390625 */
+        double exposure_auto_damping = 89.8438;
         /** Sets the exposure auto limit auto exposure mode*/
         ExposureAutoLimitAuto exposure_auto_limit_auto = EXPOSURE_AUTO_LIMIT_AUTO_OFF;
         /** Controls the device exposure time.*/
@@ -253,6 +264,8 @@ namespace camera_lucid {
         uint64_t acquisition_timeouts = 0;
         /** Number of incomplete images since start*/
         uint64_t incomplete_images = 0;
+        /** Mean exposure time*/
+        uint16_t mean_exposure; // the pattern may be different (unit64_t)
     };
 }
 

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -175,6 +175,9 @@ namespace camera_lucid {
          *  various balance ratio features.*/
         BalanceRatioSelector balance_ratio_selector =
             BalanceRatioSelector::BALANCE_RATIO_SELECTOR_RED;
+        /** Balance Ratio - Controls the selected balance ratio as an absolute physical
+         * value */
+        float balance_ratio = 1.0684;
         /** Balance White Auto - Controls the mode for automatic white balancing
          *  between color channels.*/
         BalanceWhiteAuto balance_white_auto =

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -2,6 +2,7 @@
 #define camera_lucid_TYPES_HPP
 
 #include "Arena/ArenaApi.h"
+#include <base/Float.hpp>
 #include <base/Temperature.hpp>
 #include <base/Time.hpp>
 #include <base/samples/Frame.hpp>
@@ -274,13 +275,13 @@ namespace camera_lucid {
         ExposureAutoAlgorithm exposure_auto_algorithm = EXPOSURE_AUTO_ALGORITHM_MEAN;
         /** Sets the automatic exposure damping represented as %.
          * Maximum, Minimum: 99.6094, 0.390625 */
-        double exposure_auto_damping = 89.8438;
+        double exposure_auto_damping = base::unknown<double>();
         /** Sets the exposure auto limit auto exposure mode*/
         ExposureAutoLimitAuto exposure_auto_limit_auto = EXPOSURE_AUTO_LIMIT_AUTO_OFF;
         /** Controls the device exposure time.*/
         base::Time exposure_time = base::Time::fromMilliseconds(1);
         /** Minimum exposure time.*/
-        base::Time min_exposure_time = base::Time::fromMicroseconds(46.912);
+        base::Time min_exposure_time = base::Time::fromMicroseconds(47);
         /** Maximum exposure time.*/
         base::Time max_exposure_time = base::Time::fromSeconds(10);
         /** Width of the image provided by the device in pixels.*/
@@ -319,8 +320,6 @@ namespace camera_lucid {
         uint64_t incomplete_images = 0;
         /** Mean exposure time*/
         uint64_t average_exposure;
-        /* Current balance ratio*/
-        float current_balance_ratio;
     };
 }
 

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -184,7 +184,7 @@ namespace camera_lucid {
         /** Balance White Auto Anchor Selector - Controls which type of statistics
          *  are used for BalanceWhiteAuto.*/
         BalanceWhiteAutoAnchorSelector balance_white_auto_anchor_selector =
-            BalanceWhiteAutoAnchorSelector::BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MEANRGB;
+            BalanceWhiteAutoAnchorSelector::BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MAXRGB;
     };
 
     struct PTPConfig {

--- a/camera_lucidTypes.hpp
+++ b/camera_lucidTypes.hpp
@@ -176,7 +176,9 @@ namespace camera_lucid {
             BalanceRatioSelector::BALANCE_RATIO_SELECTOR_RED;
         /** Balance Ratio - Controls the selected balance ratio as an absolute physical
          * value. This is an amplification factor applied to the video signal.*/
-        float balance_ratio = 1.0684;
+        float blue_balance_ratio = 2.1189;
+        float green_balance_ratio = 0.998047;
+        float red_balance_ratio = 1.61523;
         /** Balance White Auto - Controls the mode for automatic white balancing
          *  between color channels.*/
         BalanceWhiteAuto balance_white_auto =

--- a/online_test/task_test.rb
+++ b/online_test/task_test.rb
@@ -86,7 +86,7 @@ describe OroGen.camera_lucid.Task do
         )
 
         task.properties.camera_config = {
-            ip: "10.160.16.10",
+            ip: "10.1.1.67",
             factory_reset: false,
             camera_reset_timeout: Time.at(50),
             temperature_selector: "DEVICE_TEMPERATURE_SELECTOR_SENSOR",
@@ -100,8 +100,11 @@ describe OroGen.camera_lucid.Task do
             depth: 8,
             exposure_auto: "EXPOSURE_AUTO_OFF",
             exposure_time: Time.at(0.001),
+            exposure_auto_algorithm: :EXPOSURE_AUTO_ALGORITHM_MEAN,
+            exposure_auto_damping: 89.8438,
             min_exposure_time: Time.at(0.000_046_912),
             max_exposure_time: Time.at(0.082_446_100),
+            short_exposure_enable: false,
             width: 2448,
             height: 2048,
             offset_x: 0,
@@ -116,7 +119,13 @@ describe OroGen.camera_lucid.Task do
             gain_min: 0,
             gain_max: 48,
             gamma_enabled: true,
-            gamma: 0.5
+            gamma: 0.5,
+            balance_ratio: 1.0864,
+            balance_white_enable: true,
+            balance_ratio_selector: "BALANCE_RATIO_SELECTOR_GREEN",
+            balance_white_auto: "BALANCE_WHITE_AUTO_CONTINUOUS",
+            balance_white_auto_anchor_selector:
+                "BALANCE_WHITE_AUTO_ANCHOR_SELECTOR_MEANRGB"
         }
 
         task.properties.binning_config = {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -1001,30 +1001,6 @@ void Task::analogConfiguration(Arena::IDevice& device)
 
 void Task::balanceConfiguration(Arena::IDevice& device)
 {
-    /** Balance Ratio Selector - Selects which balance ratio is controlled by
-     * various Balance Ratio Features.*/
-
-    LOG_INFO_S << "Setting Balance Ratio Selector to ."
-               << getEnumName(_analog_controller_config.get().balance_ratio_selector,
-                      balance_ratio_selector_name);
-    Arena::SetNodeValue<gcstring>(device.GetNodeMap(),
-        "BalanceRatioSelector",
-        getEnumName(_analog_controller_config.get().balance_ratio_selector,
-            balance_ratio_selector_name));
-
-    GenApi::CEnumerationPtr balance_selector =
-        device.GetNodeMap()->GetNode("BalanceRatioSelector");
-
-    auto current = balance_selector->GetCurrentEntry()->GetSymbolic();
-    if (current != getEnumName(_analog_controller_config.get().balance_ratio_selector,
-                       balance_ratio_selector_name)) {
-        LOG_WARN_S << "BalanceRatioSelector value differs from expected: "
-                   << getEnumName(_analog_controller_config.get().balance_ratio_selector,
-                          balance_ratio_selector_name)
-                   << " current: " << current;
-        throw runtime_error("BalanceWhiteRatioSelector value differs.");
-    }
-
     /** White Balance Configuration:
      *  - Sets WhiteBalance mode (Enabled or Disabled).
      *  - Controls the balance white auto mode if it's enabled
@@ -1097,13 +1073,34 @@ void Task::balanceConfiguration(Arena::IDevice& device)
         }
     }
 
-    if ((_analog_controller_config.get().balance_white_enable == false) &&
-        (_analog_controller_config.get().balance_white_auto ==
-            BalanceWhiteAuto::BALANCE_WHITE_AUTO_OFF)) {
+    /** Balance Ratio Selector - Selects which balance ratio is controlled by
+     * various Balance Ratio Features.*/
+
+    if (_analog_controller_config.get().balance_white_auto ==
+        BalanceWhiteAuto::BALANCE_WHITE_AUTO_OFF) {
         GenApi::CFloatPtr value = device.GetNodeMap()->GetNode("BalanceRatio");
 
-        LOG_INFO_S << "Setting Balance Ratio Value";
-        value->SetValue(_analog_controller_config.get().balance_ratio);
+        LOG_INFO_S << "Setting BalanceRatioSelector to Blue";
+        Arena::SetNodeValue<gcstring>(device.GetNodeMap(),
+            "BalanceRatioSelector",
+            "Blue");
+
+        LOG_INFO_S << "Setting Blue Balance Ratio Value";
+        value->SetValue(_analog_controller_config.get().blue_balance_ratio);
+
+        LOG_INFO_S << "Setting BalanceRatioSelector to Green";
+        Arena::SetNodeValue<gcstring>(device.GetNodeMap(),
+            "BalanceRatioSelector",
+            "Green");
+
+        LOG_INFO_S << "Setting Green Balance Ratio Value";
+        value->SetValue(_analog_controller_config.get().green_balance_ratio);
+
+        LOG_INFO_S << "Setting BalanceRatioSelector to RED";
+        Arena::SetNodeValue<gcstring>(device.GetNodeMap(), "BalanceRatioSelector", "Red");
+
+        LOG_INFO_S << "Setting Red Balance Ratio Value";
+        value->SetValue(_analog_controller_config.get().red_balance_ratio);
     }
 }
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -782,6 +782,22 @@ void Task::exposureConfiguration(Arena::IDevice& device)
             getEnumName(image_config.exposure_auto_limit_auto,
                 exposure_auto_limit_auto_name));
 
+        LOG_INFO_S << "Setting auto exposure algorithm to"
+                   << getEnumName(image_config.exposure_auto_algorithm,
+                          exposure_auto_algorithm);
+
+        Arena::SetNodeValue<gcstring>(device.GetNodeMap(),
+            "ExposureAutoAlgorithm",
+            getEnumName(image_config.exposure_auto_algorithm, exposure_auto_algorithm));
+
+        LOG_INFO_S << "Setting device's target brightness to "
+                   << image_config.exposure_auto_damping;
+
+        GenApi::CIntegerPtr exposureAutoDamping =
+            device.GetNodeMap()->GetNode("ExposureAutoDamping");
+
+        exposureAutoDamping->SetValue(image_config.exposure_auto_damping);
+
         if (image_config.exposure_auto_limit_auto ==
             ExposureAutoLimitAuto::EXPOSURE_AUTO_LIMIT_AUTO_OFF) {
             LOG_INFO_S << "Setting exposure time lower and upper limit";
@@ -1022,6 +1038,8 @@ void Task::collectInfo()
                               device_temperature_selector_name);
             info_message.temperature = info_message.temperature.fromCelsius(
                 Arena::GetNodeValue<double>(m_device->GetNodeMap(), "DeviceTemperature"));
+            info_message.mean_exposure =
+                Arena::GetNodeValue<double>(m_device->GetNodeMap(), "CalculatedMean");
             info_message.acquisition_timeouts = m_acquisition_timeouts_sum;
             info_message.incomplete_images = m_incomplete_images_sum;
         }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -810,13 +810,15 @@ void Task::exposureConfiguration(Arena::IDevice& device)
             throw runtime_error("ExposureAutoAlgorithm value differs.");
         }
 
-        LOG_INFO_S << "Setting device's exposure auto damping to "
-                   << image_config.exposure_auto_damping;
+        if (!base::isUnknown(image_config.exposure_auto_damping)) {
+            LOG_INFO_S << "Setting device's exposure auto damping to "
+                       << image_config.exposure_auto_damping;
 
-        GenApi::CFloatPtr exposureAutoDamping =
-            device.GetNodeMap()->GetNode("ExposureAutoDamping");
+            GenApi::CFloatPtr exposureAutoDamping =
+                device.GetNodeMap()->GetNode("ExposureAutoDamping");
 
-        exposureAutoDamping->SetValue(image_config.exposure_auto_damping);
+            exposureAutoDamping->SetValue(image_config.exposure_auto_damping);
+        }
 
         if ((image_config.exposure_auto_limit_auto ==
                 ExposureAutoLimitAuto::EXPOSURE_AUTO_LIMIT_AUTO_OFF) &&
@@ -1171,8 +1173,6 @@ void Task::collectInfo()
                 Arena::GetNodeValue<double>(m_device->GetNodeMap(), "DeviceTemperature"));
             info_message.average_exposure =
                 Arena::GetNodeValue<int64_t>(m_device->GetNodeMap(), "CalculatedMean");
-            info_message.current_balance_ratio =
-                Arena::GetNodeValue<double>(m_device->GetNodeMap(), "BalanceRatio");
             info_message.acquisition_timeouts = m_acquisition_timeouts_sum;
             info_message.incomplete_images = m_incomplete_images_sum;
         }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -819,8 +819,8 @@ void Task::exposureConfiguration(Arena::IDevice& device)
         exposureAutoDamping->SetValue(image_config.exposure_auto_damping);
 
         if ((image_config.exposure_auto_limit_auto ==
-            ExposureAutoLimitAuto::EXPOSURE_AUTO_LIMIT_AUTO_OFF) && 
-             (image_config.short_exposure_enable == false)) {
+                ExposureAutoLimitAuto::EXPOSURE_AUTO_LIMIT_AUTO_OFF) &&
+            (image_config.short_exposure_enable == false)) {
             LOG_INFO_S << "Setting exposure time lower and upper limit";
 
             GenApi::CFloatPtr lowerLimit =

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -785,11 +785,25 @@ void Task::exposureConfiguration(Arena::IDevice& device)
 
         LOG_INFO_S << "Setting auto exposure algorithm to"
                    << getEnumName(image_config.exposure_auto_algorithm,
-                          exposure_auto_algorithm);
+                          exposure_auto_algorithm_name);
 
         Arena::SetNodeValue<gcstring>(device.GetNodeMap(),
             "ExposureAutoAlgorithm",
-            getEnumName(image_config.exposure_auto_algorithm, exposure_auto_algorithm));
+            getEnumName(image_config.exposure_auto_algorithm,
+                exposure_auto_algorithm_name));
+
+        GenApi::CEnumerationPtr exposureAutoAlgorithm =
+            device.GetNodeMap()->GetNode("ExposureAutoAlgorithm");
+
+        auto current_algorithm = exposureAutoAlgorithm->GetCurrentEntry()->GetSymbolic();
+        if (current_algorithm != getEnumName(image_config.exposure_auto_algorithm,
+                                     exposure_auto_algorithm_name)) {
+            LOG_WARN_S << "ExposureAutoAlgorithm value differs setpoint: "
+                       << getEnumName(image_config.exposure_auto_algorithm,
+                              exposure_auto_algorithm_name)
+                       << " current: " << current_algorithm;
+            throw runtime_error("ExposureAutoAlgorithm value differs.");
+        }
 
         LOG_INFO_S << "Setting device's exposure auto damping to "
                    << image_config.exposure_auto_damping;

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -777,6 +777,11 @@ void Task::exposureConfiguration(Arena::IDevice& device)
      *  - Checks if exposure auto is off
      *      - Sets fixed exposure time
      * */
+    LOG_INFO_S << "Setting Short Exposure State";
+    Arena::SetNodeValue<bool>(device.GetNodeMap(),
+        "ShortExposureEnable",
+        image_config.short_exposure_enable);
+
     if (image_config.exposure_auto == ExposureAuto::EXPOSURE_AUTO_CONTINUOUS) {
         Arena::SetNodeValue<gcstring>(device.GetNodeMap(),
             "ExposureAutoLimitAuto",
@@ -813,8 +818,9 @@ void Task::exposureConfiguration(Arena::IDevice& device)
 
         exposureAutoDamping->SetValue(image_config.exposure_auto_damping);
 
-        if (image_config.exposure_auto_limit_auto ==
-            ExposureAutoLimitAuto::EXPOSURE_AUTO_LIMIT_AUTO_OFF) {
+        if ((image_config.exposure_auto_limit_auto ==
+            ExposureAutoLimitAuto::EXPOSURE_AUTO_LIMIT_AUTO_OFF) && 
+             (image_config.short_exposure_enable == false)) {
             LOG_INFO_S << "Setting exposure time lower and upper limit";
 
             GenApi::CFloatPtr lowerLimit =

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -791,10 +791,10 @@ void Task::exposureConfiguration(Arena::IDevice& device)
             "ExposureAutoAlgorithm",
             getEnumName(image_config.exposure_auto_algorithm, exposure_auto_algorithm));
 
-        LOG_INFO_S << "Setting device's target brightness to "
+        LOG_INFO_S << "Setting device's exposure auto damping to "
                    << image_config.exposure_auto_damping;
 
-        GenApi::CIntegerPtr exposureAutoDamping =
+        GenApi::CFloatPtr exposureAutoDamping =
             device.GetNodeMap()->GetNode("ExposureAutoDamping");
 
         exposureAutoDamping->SetValue(image_config.exposure_auto_damping);
@@ -1070,8 +1070,6 @@ void Task::balanceConfiguration(Arena::IDevice& device)
             throw runtime_error("BalanceWhiteAutoAnchorSelector value differs.");
         }
     }
-
-    LOG_INFO_S << "_analog_controller_config.get().balance_white_auto: " << (_analog_controller_config.get().balance_white_auto);
 
     if ((_analog_controller_config.get().balance_white_enable == false) &&
         (_analog_controller_config.get().balance_white_auto ==

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -1174,6 +1174,8 @@ void Task::collectInfo()
                 Arena::GetNodeValue<double>(m_device->GetNodeMap(), "DeviceTemperature"));
             info_message.average_exposure =
                 Arena::GetNodeValue<int64_t>(m_device->GetNodeMap(), "CalculatedMean");
+            info_message.current_balance_ratio =
+                Arena::GetNodeValue<double>(m_device->GetNodeMap(), "BalanceRatio");
             info_message.acquisition_timeouts = m_acquisition_timeouts_sum;
             info_message.incomplete_images = m_incomplete_images_sum;
         }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -857,13 +857,19 @@ void Task::exposureConfiguration(Arena::IDevice& device)
      *  - Sets target brightness value
      *  - Note: 70 is the optimal target brightness value for outdoor
      *  usage, as stated in the camera's manual. */
-    LOG_INFO_S << "Setting device's target brightness to "
-               << image_config.target_brightness;
+    if (image_config.exposure_auto == ExposureAuto::EXPOSURE_AUTO_ONCE) {
+        LOG_WARN_S << "Target Brightness cannot be set when "
+                   << "ExposureAuto is set to ONCE";
+    }
+    else {
+        LOG_INFO_S << "Setting device's target brightness to "
+                   << image_config.target_brightness;
 
-    GenApi::CIntegerPtr targetBrightness =
-        device.GetNodeMap()->GetNode("TargetBrightness");
+        GenApi::CIntegerPtr targetBrightness =
+            device.GetNodeMap()->GetNode("TargetBrightness");
 
-    targetBrightness->SetValue(image_config.target_brightness);
+        targetBrightness->SetValue(image_config.target_brightness);
+    }
 }
 
 void Task::acquisitionConfiguration(Arena::IDevice& device)

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -973,7 +973,32 @@ void Task::analogConfiguration(Arena::IDevice& device)
     value->SetValue(_analog_controller_config.get().gamma);
 }
 
-void Task::balanceConfiguration(Arena::IDevice& device) {
+void Task::balanceConfiguration(Arena::IDevice& device)
+{
+    /** Balance Ratio Selector - Selects which balance ratio is controlled by
+     * various Balance Ratio Features.*/
+
+    LOG_INFO_S << "Setting Balance Ratio Selector to ."
+               << getEnumName(_analog_controller_config.get().balance_ratio_selector,
+                      balance_ratio_selector_name);
+    Arena::SetNodeValue<gcstring>(device.GetNodeMap(),
+        "BalanceRatioSelector",
+        getEnumName(_analog_controller_config.get().balance_ratio_selector,
+            balance_ratio_selector_name));
+
+    GenApi::CEnumerationPtr balance_selector =
+        device.GetNodeMap()->GetNode("BalanceRatioSelector");
+
+    auto current = balance_selector->GetCurrentEntry()->GetSymbolic();
+    if (current != getEnumName(_analog_controller_config.get().balance_ratio_selector,
+                       balance_ratio_selector_name)) {
+        LOG_WARN_S << "BalanceRatioSelector value differs from expected: "
+                   << getEnumName(_analog_controller_config.get().balance_ratio_selector,
+                          balance_ratio_selector_name)
+                   << " current: " << current;
+        throw runtime_error("BalanceWhiteAuto value differs.");
+    }
+
     /** White Balance Configuration:
      *  - Sets WhiteBalance mode (Enabled or Disabled).
      *  - Controls the balance white auto mode if it's enabled
@@ -991,11 +1016,11 @@ void Task::balanceConfiguration(Arena::IDevice& device) {
         device.GetNodeMap()->GetNode("BalanceWhiteEnable");
     bool current_bool = white_balance_enabled->GetValue();
     if (current_bool != _analog_controller_config.get().balance_white_enable) {
-            LOG_WARN_S << "BalanceWhiteAuto value differs from expected: "
-                       << _analog_controller_config.get().balance_white_enable
-                       << " current: " << current_bool;
-            throw runtime_error("BalanceWhiteAuto value differs.");
-        }
+        LOG_WARN_S << "BalanceWhiteAuto value differs from expected: "
+                   << _analog_controller_config.get().balance_white_enable
+                   << " current: " << current_bool;
+        throw runtime_error("BalanceWhiteAuto value differs.");
+    }
 
     if (_analog_controller_config.get().balance_white_enable == true) {
         LOG_INFO_S << "Setting Balance White Auto to ."
@@ -1009,7 +1034,7 @@ void Task::balanceConfiguration(Arena::IDevice& device) {
         GenApi::CEnumerationPtr balance_auto =
             device.GetNodeMap()->GetNode("BalanceWhiteAuto");
 
-        auto current = balance_auto->GetCurrentEntry()->GetSymbolic();
+        current = balance_auto->GetCurrentEntry()->GetSymbolic();
         if (current != getEnumName(_analog_controller_config.get().balance_white_auto,
                            balance_white_auto_name)) {
             LOG_WARN_S << "BalanceWhiteAuto value differs from expected: "
@@ -1118,8 +1143,8 @@ void Task::collectInfo()
                               device_temperature_selector_name);
             info_message.temperature = info_message.temperature.fromCelsius(
                 Arena::GetNodeValue<double>(m_device->GetNodeMap(), "DeviceTemperature"));
-            info_message.mean_exposure =
-                Arena::GetNodeValue<double>(m_device->GetNodeMap(), "CalculatedMean");
+            info_message.average_exposure =
+                Arena::GetNodeValue<int64_t>(m_device->GetNodeMap(), "CalculatedMean");
             info_message.acquisition_timeouts = m_acquisition_timeouts_sum;
             info_message.incomplete_images = m_incomplete_images_sum;
         }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -130,6 +130,7 @@ argument.
         void exposureConfiguration(Arena::IDevice& device);
         void infoConfiguration(Arena::IDevice& device);
         void analogConfiguration(Arena::IDevice& device);
+        void balanceConfiguration(Arena::IDevice& device);
         void transmissionConfiguration(Arena::IDevice& device);
         bool checkMtu(Arena::IDevice& device, int64_t mtu);
 


### PR DESCRIPTION
# What is this PR for
<!-- A clear description of what this PR do and the changes made.
If you want you can also add the shortcut link here -->
- [x] [Shortcut](https://app.shortcut.com/tidewise/story/41013/add-missing-control-settings-to-the-lucid-component)

The lucid cameras were under performing in dark scenarios, these configurations enable a wider number of configuration parameters for both the auto-exposure and the white balance.
As for the white balance, the lucid cameras have a NIR filter and despite it's upsides we have a major downside regarding night time operations, it makes the image darker. With the removal of the filter the colors were too red, hence the need to re-configure the white balance.
Finally, i've also discovered a bug involving target brightness which is better explained on the commit that fixes it.

# How I did it
<!-- Explain a little bit of your implementation -->
Added new configuration options to the driver by altering values on the nodes.

# Results, How I tested
<!-- Explain how you tested you PR, if there is a visual output,
     a GIF or image is welcome -->
Empyrical testing with the camera on the office.
Test using the online_test.rb

# Checklist
- [x] Assign yourself  in the PR
- [x] Write unit tests (when relevant)